### PR TITLE
CP-9: integrate supabase db to save park pass info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@rneui/base": "^4.0.0-rc.7",
         "@rneui/themed": "^4.0.0-rc.8",
         "@supabase/supabase-js": "^2.43.1",
+        "@tanstack/react-query": "^5.35.1",
         "expo": "~50.0.17",
         "expo-font": "~11.10.3",
         "expo-linking": "~6.2.2",
@@ -7246,6 +7247,30 @@
         "@supabase/postgrest-js": "1.15.2",
         "@supabase/realtime-js": "2.9.5",
         "@supabase/storage-js": "2.5.5"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.35.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.35.1.tgz",
+      "integrity": "sha512-0Dnpybqb8+ps6WgqBnqFEC+1F/xLvUosRAq+wiGisTgolOZzqZfkE2995dEXmhuzINiTM7/a6xSGznU0NIvBkw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.35.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.35.1.tgz",
+      "integrity": "sha512-i2T7m2ffQdNqlX3pO+uMsnQ0H4a59Ens2GxtlMsRiOvdSB4SfYmHb27MnvFV8rGmtWRaa4gPli0/rpDoSS5LbQ==",
+      "dependencies": {
+        "@tanstack/query-core": "5.35.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@rneui/base": "^4.0.0-rc.7",
     "@rneui/themed": "^4.0.0-rc.8",
     "@supabase/supabase-js": "^2.43.1",
+    "@tanstack/react-query": "^5.35.1",
     "expo": "~50.0.17",
     "expo-font": "~11.10.3",
     "expo-linking": "~6.2.2",

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -12,6 +12,7 @@ import { useEffect } from 'react';
 import { useColorScheme } from '@/src/components/useColorScheme';
 import { AuthProvider } from '../providers/AuthProvider';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import QueryProvider from '../providers/QueryProvider';
 
 export {
   // Catch any errors thrown by the Layout component.
@@ -56,13 +57,15 @@ function RootLayoutNav() {
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <AuthProvider>
-        <SafeAreaView style={{ flex: 1 }}>
-          <Stack>
-            <Stack.Screen name='(auth)' options={{ headerShown: false }} />
-            <Stack.Screen name='(user)' options={{ headerShown: false }} />
-            <Stack.Screen name='modal' options={{ presentation: 'modal' }} />
-          </Stack>
-        </SafeAreaView>
+        <QueryProvider>
+          <SafeAreaView style={{ flex: 1 }}>
+            <Stack>
+              <Stack.Screen name='(auth)' options={{ headerShown: false }} />
+              <Stack.Screen name='(user)' options={{ headerShown: false }} />
+              <Stack.Screen name='modal' options={{ presentation: 'modal' }} />
+            </Stack>
+          </SafeAreaView>
+        </QueryProvider>
       </AuthProvider>
     </ThemeProvider>
   );

--- a/src/app/api/park-pass/index.ts
+++ b/src/app/api/park-pass/index.ts
@@ -1,0 +1,30 @@
+import { useMutation } from '@tanstack/react-query';
+import { supabase } from '../../../lib/supabase';
+import { ParkPass } from '../../../types';
+
+interface InsertParkPass {
+  item: ParkPass;
+  userId: string;
+}
+
+export const useInsertParkPass = () => {
+  return useMutation({
+    async mutationFn({ item, userId }: InsertParkPass) {
+      const { error, data: addedParkPass } = await supabase
+        .from('park_pass')
+        .insert({
+          name: item.name,
+          expiry_date: item.expiryDate,
+          user_id: userId,
+        })
+        .eq('id', userId)
+        .select();
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      return addedParkPass;
+    },
+  });
+};

--- a/src/database.types.ts
+++ b/src/database.types.ts
@@ -1,0 +1,352 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  public: {
+    Tables: {
+      check_list: {
+        Row: {
+          created_at: string
+          id: number
+          items: Json[] | null
+          uid: string | null
+        }
+        Insert: {
+          created_at?: string
+          id?: number
+          items?: Json[] | null
+          uid?: string | null
+        }
+        Update: {
+          created_at?: string
+          id?: number
+          items?: Json[] | null
+          uid?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "check_list_uid_fkey"
+            columns: ["uid"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      park_pass: {
+        Row: {
+          created_at: string
+          expiry_date: string | null
+          id: number
+          name: string | null
+          uid: string | null
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          expiry_date?: string | null
+          id?: number
+          name?: string | null
+          uid?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          expiry_date?: string | null
+          id?: number
+          name?: string | null
+          uid?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "park_pass_uid_fkey"
+            columns: ["uid"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "park_pass_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      profiles: {
+        Row: {
+          avatar_url: string | null
+          full_name: string | null
+          id: string
+          text: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          avatar_url?: string | null
+          full_name?: string | null
+          id: string
+          text?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          avatar_url?: string | null
+          full_name?: string | null
+          id?: string
+          text?: string | null
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "profiles_id_fkey"
+            columns: ["id"]
+            isOneToOne: true
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      site_info: {
+        Row: {
+          arrival: string | null
+          camp_ground_name: string | null
+          camping_type: Database["public"]["Enums"]["camping_type"] | null
+          can_purchase_fire_wood: boolean | null
+          car_access: Database["public"]["Enums"]["car_access_type"] | null
+          created_at: string
+          departure: string | null
+          fire_wood_price: number | null
+          has_drinkable_water: boolean | null
+          has_electric: boolean | null
+          has_fire_pit: boolean | null
+          has_sewer_service: boolean | null
+          has_shower: boolean | null
+          has_signal: boolean | null
+          has_sink: boolean | null
+          has_stores: boolean | null
+          id: number
+          is_fire_wood_unlimited: boolean | null
+          is_waterfront: boolean | null
+          location: string | null
+          need_park_pass: boolean | null
+          need_reservation: boolean | null
+          note: string | null
+          park_pass_name: string | null
+          privacy: Database["public"]["Enums"]["privacy_type"] | null
+          rating: number | null
+          reservation_fee: number | null
+          shower_cost: number | null
+          site_fee: number | null
+          site_number: number | null
+          site_size: Database["public"]["Enums"]["site_size_type"] | null
+          toilet: Database["public"]["Enums"]["toilet_type"] | null
+          uid: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          arrival?: string | null
+          camp_ground_name?: string | null
+          camping_type?: Database["public"]["Enums"]["camping_type"] | null
+          can_purchase_fire_wood?: boolean | null
+          car_access?: Database["public"]["Enums"]["car_access_type"] | null
+          created_at?: string
+          departure?: string | null
+          fire_wood_price?: number | null
+          has_drinkable_water?: boolean | null
+          has_electric?: boolean | null
+          has_fire_pit?: boolean | null
+          has_sewer_service?: boolean | null
+          has_shower?: boolean | null
+          has_signal?: boolean | null
+          has_sink?: boolean | null
+          has_stores?: boolean | null
+          id?: number
+          is_fire_wood_unlimited?: boolean | null
+          is_waterfront?: boolean | null
+          location?: string | null
+          need_park_pass?: boolean | null
+          need_reservation?: boolean | null
+          note?: string | null
+          park_pass_name?: string | null
+          privacy?: Database["public"]["Enums"]["privacy_type"] | null
+          rating?: number | null
+          reservation_fee?: number | null
+          shower_cost?: number | null
+          site_fee?: number | null
+          site_number?: number | null
+          site_size?: Database["public"]["Enums"]["site_size_type"] | null
+          toilet?: Database["public"]["Enums"]["toilet_type"] | null
+          uid?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          arrival?: string | null
+          camp_ground_name?: string | null
+          camping_type?: Database["public"]["Enums"]["camping_type"] | null
+          can_purchase_fire_wood?: boolean | null
+          car_access?: Database["public"]["Enums"]["car_access_type"] | null
+          created_at?: string
+          departure?: string | null
+          fire_wood_price?: number | null
+          has_drinkable_water?: boolean | null
+          has_electric?: boolean | null
+          has_fire_pit?: boolean | null
+          has_sewer_service?: boolean | null
+          has_shower?: boolean | null
+          has_signal?: boolean | null
+          has_sink?: boolean | null
+          has_stores?: boolean | null
+          id?: number
+          is_fire_wood_unlimited?: boolean | null
+          is_waterfront?: boolean | null
+          location?: string | null
+          need_park_pass?: boolean | null
+          need_reservation?: boolean | null
+          note?: string | null
+          park_pass_name?: string | null
+          privacy?: Database["public"]["Enums"]["privacy_type"] | null
+          rating?: number | null
+          reservation_fee?: number | null
+          shower_cost?: number | null
+          site_fee?: number | null
+          site_number?: number | null
+          site_size?: Database["public"]["Enums"]["site_size_type"] | null
+          toilet?: Database["public"]["Enums"]["toilet_type"] | null
+          uid?: string | null
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "site_info_uid_fkey"
+            columns: ["uid"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      test: {
+        Row: {
+          created_at: string
+          id: string
+          text: string | null
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          text?: string | null
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          text?: string | null
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      [_ in never]: never
+    }
+    Enums: {
+      camping_type: "FRONT" | "BACK" | "GLAMPING" | "CROWN"
+      car_access_type: "ON_SITE" | "ON_SITE_THROUGH" | "PARKING_LOT"
+      privacy_type: "POOR" | "BAD" | "AVERAGE" | "GOOD" | "GREAT"
+      site_size_type: "SMALL" | "MEDIUM" | "LARGE"
+      toilet_type: "FLUSH" | "VAULT"
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type PublicSchema = Database[Extract<keyof Database, "public">]
+
+export type Tables<
+  PublicTableNameOrOptions extends
+    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+        Database[PublicTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
+        PublicSchema["Views"])
+    ? (PublicSchema["Tables"] &
+        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  PublicEnumNameOrOptions extends
+    | keyof PublicSchema["Enums"]
+    | { schema: keyof Database },
+  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = PublicEnumNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
+    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+    : never

--- a/src/providers/QueryProvider.tsx
+++ b/src/providers/QueryProvider.tsx
@@ -1,0 +1,8 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { PropsWithChildren } from 'react';
+
+const client = new QueryClient();
+
+export default function QueryProvider({ children }: PropsWithChildren) {
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,18 @@
+import { Database } from './database.types';
+
+export type Tables<T extends keyof Database['public']['Tables']> =
+  Database['public']['Tables'][T]['Row'];
+
+export type InsertTables<T extends keyof Database['public']['Tables']> =
+  Database['public']['Tables'][T]['Insert'];
+
+export type UpdateTables<T extends keyof Database['public']['Tables']> =
+  Database['public']['Tables'][T]['Update'];
+
+export type Enums<T extends keyof Database['public']['Enums']> =
+  Database['public']['Enums'][T];
+
+export interface ParkPass {
+  name: string;
+  expiryDate: string;
+}


### PR DESCRIPTION
## Pull Request

**Description:**
< react-query >
-   Installed react-query(tankstak)
-   Created QueryProvider
-   Wrapped it around app/_layout.tsx
-   useMutation to insert park pass info (app/api/park-pass/index.ts)
-   used useInsertParkPass in Park Pass Modal

< Type >
- Generated DB type via Supabase
- Added DB type helper 

< Supabase DB > 
-   Add user_id(FK) to park_pass table to connect profile table
-   Check the information saved in Supabase DB

**Checklist:**

- [x] I have tested the changes locally.
- [x] I have updated the documentation(if applicable).

**Screenshots (if applicable):**
<img width="1422" alt="Screenshot 2024-05-08 at 9 40 03 PM" src="https://github.com/Seolcita/marshmellow/assets/83251839/463a47ea-a8be-4c8e-836f-92c7ea985bfe">

**Future Works:**
- N/A